### PR TITLE
Add NinjaAI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ MCP SuperAssistant is a Chrome extension that integrates the Model Context Proto
 - [GitHub Copilot](https://github.com/copilot)
 - [Mistral AI](https://chat.mistral.ai/)
 - [Kimi](https://kimi.com/)
+- [NinjaAI](https://ninjatech.ai/)
 
 
 ## Demo Video

--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -45,6 +45,7 @@ const manifest = {
     '*://*.github.com/*',
     '*://*.copilot.github.com/*',
     '*://*.kimi.com/*',
+    '*://*.ninjatech.ai/*',
   ],
 
   permissions: ['storage', 'clipboardWrite'],
@@ -146,6 +147,12 @@ const manifest = {
     // Specific content script for Kimi
     {
       matches: ['*://*.kimi.com/*'],
+      js: ['content/index.iife.js'],
+      run_at: 'document_idle',
+    },
+    // Specific content script for NinjaAI tool call parsing
+    {
+      matches: ['*://*.ninjatech.ai/*'],
       js: ['content/index.iife.js'],
       run_at: 'document_idle',
     },

--- a/pages/content/src/components/sidebar/SidebarManager.tsx
+++ b/pages/content/src/components/sidebar/SidebarManager.tsx
@@ -54,6 +54,7 @@ export class SidebarManager extends BaseSidebarManager {
   private static deepseekInstance: SidebarManager | null = null;
   private static kagiInstance: SidebarManager | null = null;
   private static t3chatInstance: SidebarManager | null = null;
+  private static ninjaInstance: SidebarManager | null = null;
   private lastToolOutputsHash: string = '';
   private lastMcpToolsHash: string = '';
   private isFirstLoad: boolean = true;
@@ -129,6 +130,11 @@ export class SidebarManager extends BaseSidebarManager {
           SidebarManager.t3chatInstance = new SidebarManager(siteType);
         }
         return SidebarManager.t3chatInstance;
+      case 'ninja':
+        if (!SidebarManager.ninjaInstance) {
+          SidebarManager.ninjaInstance = new SidebarManager(siteType);
+        }
+        return SidebarManager.ninjaInstance;
       default:
         // For any unexpected site type, create and return a new instance
         logMessage(`Creating new SidebarManager for unknown site type: ${siteType}`);
@@ -628,6 +634,11 @@ export class SidebarManager extends BaseSidebarManager {
       case 't3chat':
         if (SidebarManager.t3chatInstance === this) {
           SidebarManager.t3chatInstance = null;
+        }
+        break;
+      case 'ninja':
+        if (SidebarManager.ninjaInstance === this) {
+          SidebarManager.ninjaInstance = null;
         }
         break;
     }

--- a/pages/content/src/components/sidebar/base/BaseSidebarManager.tsx
+++ b/pages/content/src/components/sidebar/base/BaseSidebarManager.tsx
@@ -22,7 +22,8 @@ export type SiteType =
   | 'openrouter'
   | 'deepseek'
   | 'kagi'
-  | 't3chat';
+  | 't3chat'
+  | 'ninja';
 
 /**
  * BaseSidebarManager is a base class for creating sidebar managers

--- a/pages/content/src/components/websites/ninja/chatInputHandler.ts
+++ b/pages/content/src/components/websites/ninja/chatInputHandler.ts
@@ -1,0 +1,64 @@
+/**
+ * Simple utilities for NinjaAI chat input
+ */
+
+import { logMessage } from '@src/utils/helpers';
+
+let lastFoundInputElement: HTMLElement | null = null;
+
+export const findChatInputElement = (): HTMLElement | null => {
+  const selectors = [
+    'textarea.ThreadInputBox_textArea__caqN+',
+    'textarea[placeholder*="Ask anything"]',
+    'div[contenteditable="true"]'
+  ];
+
+  for (const selector of selectors) {
+    const el = document.querySelector(selector);
+    if (el) {
+      lastFoundInputElement = el as HTMLElement;
+      return el as HTMLElement;
+    }
+  }
+
+  if (lastFoundInputElement && document.body.contains(lastFoundInputElement)) {
+    return lastFoundInputElement;
+  }
+
+  return null;
+};
+
+export const insertTextToChatInput = (text: string): boolean => {
+  const input = findChatInputElement();
+  if (!input) {
+    logMessage('Could not find NinjaAI input element');
+    return false;
+  }
+  if (input.tagName === 'TEXTAREA') {
+    (input as HTMLTextAreaElement).value = text;
+  } else {
+    input.textContent = text;
+  }
+  input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+  (input as HTMLElement).focus();
+  return true;
+};
+
+export const submitChatInput = async (): Promise<boolean> => {
+  const button = document.querySelector<HTMLButtonElement>(
+    'button.nj-chat-form--submit-button, button[data-e2e="main-submit-button"]'
+  );
+  if (!button) return false;
+  button.click();
+  return true;
+};
+
+export const attachFileToInput = async (file: File): Promise<boolean> => {
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) return false;
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  input.files = dt.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  return true;
+};

--- a/pages/content/src/components/websites/ninja/index.ts
+++ b/pages/content/src/components/websites/ninja/index.ts
@@ -1,0 +1,2 @@
+export * from './chatInputHandler';
+export { SidebarManager } from '@src/components/sidebar';

--- a/pages/content/src/plugins/adapters/index.ts
+++ b/pages/content/src/plugins/adapters/index.ts
@@ -16,6 +16,7 @@ export { DeepSeekAdapter } from './deepseek.adapter';
 export { T3ChatAdapter } from './t3chat.adapter';
 export { MistralAdapter } from './mistral.adapter';
 export { GitHubCopilotAdapter } from './ghcopilot.adapter';
+export { NinjaAdapter } from './ninja.adapter';
 
 
 // Export types

--- a/pages/content/src/plugins/adapters/ninja.adapter.ts
+++ b/pages/content/src/plugins/adapters/ninja.adapter.ts
@@ -1,0 +1,66 @@
+import { BaseAdapterPlugin } from './base.adapter';
+import type { AdapterCapability, PluginContext } from '../plugin-types';
+
+/**
+ * Ninja Adapter for NinjaAI (ninjatech.ai)
+ *
+ * Provides basic text insertion and form submission support.
+ */
+export class NinjaAdapter extends BaseAdapterPlugin {
+  readonly name = 'NinjaAdapter';
+  readonly version = '1.0.0';
+  readonly hostnames = ['ninjatech.ai'];
+  readonly capabilities: AdapterCapability[] = [
+    'text-insertion',
+    'form-submission',
+    'file-attachment',
+    'dom-manipulation'
+  ];
+
+  private readonly selectors = {
+    CHAT_INPUT:
+      'textarea.ThreadInputBox_textArea__caqN+, textarea[placeholder*="Ask anything"]',
+    SUBMIT_BUTTON:
+      'button.nj-chat-form--submit-button, button[data-e2e="main-submit-button"]',
+    FILE_UPLOAD_BUTTON:
+      'button[data-tooltip-content="Attach files"], button[aria-label*="attach"]',
+    FILE_INPUT: 'input[type="file"]',
+    MAIN_PANEL: '.nj-thread-view--chat, .ManageTasksChatPage_container__Lz6gp',
+    DROP_ZONE: 'textarea.ThreadInputBox_textArea__caqN+',
+    FILE_PREVIEW: '.file-preview, .attachment-preview',
+    BUTTON_INSERTION_CONTAINER:
+      '.ThreadInputBox_actionsLtr__vvyJM, .ThreadInputBox_containerRow__v+hPl',
+    FALLBACK_INSERTION: '.nj-thread-view--landing-page-wrapper'
+  } as const;
+
+  async initialize(context: PluginContext): Promise<void> {
+    await super.initialize(context);
+  }
+
+  async insertText(text: string): Promise<boolean> {
+    const el = document.querySelector<HTMLTextAreaElement | HTMLElement>(
+      this.selectors.CHAT_INPUT
+    );
+    if (!el) {
+      this.context.logger.error('Ninja chat input not found');
+      return false;
+    }
+    if (el instanceof HTMLTextAreaElement) {
+      el.value = text;
+    } else {
+      el.textContent = text;
+    }
+    el.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    (el as HTMLElement).focus();
+    return true;
+  }
+
+  async submitForm(): Promise<boolean> {
+    const btn = document.querySelector<HTMLButtonElement>(
+      this.selectors.SUBMIT_BUTTON
+    );
+    if (!btn) return false;
+    btn.click();
+    return true;
+  }
+}

--- a/pages/content/src/plugins/index.ts
+++ b/pages/content/src/plugins/index.ts
@@ -12,6 +12,7 @@ export { T3ChatAdapter } from './adapters/t3chat.adapter';
 export { AIStudioAdapter } from './adapters/aistudio.adapter';
 export { MistralAdapter } from './adapters/mistral.adapter';
 export { GitHubCopilotAdapter } from './adapters/ghcopilot.adapter';
+export { NinjaAdapter } from './adapters/ninja.adapter';
 export { SidebarPlugin } from './sidebar.plugin';
 export { createPluginContext } from './plugin-context';
 

--- a/pages/content/src/plugins/plugin-registry.ts
+++ b/pages/content/src/plugins/plugin-registry.ts
@@ -24,6 +24,7 @@ import { MistralAdapter } from './adapters/mistral.adapter';
 import { SidebarPlugin } from './sidebar.plugin';
 import { ChatGPTAdapter } from './adapters/chatgpt.adapter';
 import { KimiAdapter } from './adapters/kimi.adapter';
+import { NinjaAdapter } from './adapters/ninja.adapter';
 import { RemoteConfigPlugin } from './remote-config.plugin';
 
 // Types for lazy initialization
@@ -946,6 +947,29 @@ class PluginRegistry {
             urlCheckInterval: 1000,
           },
         },
+      });
+
+      // Register NinjaAdapter factory for NinjaAI
+      this.registerAdapterFactory({
+        name: 'ninja-adapter',
+        version: '1.0.0',
+        type: 'website-adapter',
+        hostnames: ['ninjatech.ai'],
+        capabilities: ['text-insertion', 'form-submission', 'file-attachment'],
+        create: () => new NinjaAdapter(),
+        config: {
+          id: 'ninja-adapter',
+          name: 'Ninja Adapter',
+          description:
+            'Basic adapter for NinjaAI with chat input and form submission support',
+          version: '1.0.0',
+          enabled: true,
+          priority: 5,
+          settings: {
+            logLevel: 'info',
+            urlCheckInterval: 1000
+          }
+        }
       });
       
       console.debug(`[PluginRegistry] Successfully registered SidebarPlugin (initialized) and ${this.adapterFactories.size} adapter factories (lazy)`);

--- a/pages/content/src/plugins/sidebar.plugin.ts
+++ b/pages/content/src/plugins/sidebar.plugin.ts
@@ -267,6 +267,7 @@ export class SidebarPlugin implements AdapterPlugin {
     if (hostname.includes('chat.deepseek.com')) return 'deepseek';
     if (hostname.includes('kagi.com')) return 'kagi';
     if (hostname.includes('t3.chat')) return 't3chat';
+    if (hostname.includes('ninjatech.ai')) return 'ninja';
 
     // Default to perplexity for unknown sites
     return 'perplexity';

--- a/pages/content/src/render_prescript/src/core/config.ts
+++ b/pages/content/src/render_prescript/src/core/config.ts
@@ -169,6 +169,14 @@ export const WEBSITE_CONFIGS: Array<{
       function_result_selector: ['div[class*="user-content"]'],
     },
   },
+  {
+    urlPattern: 'ninjatech.ai',
+    config: {
+      targetSelectors: ['pre'],
+      streamingContainerSelectors: ['pre'],
+      function_result_selector: ['pre']
+    },
+  },
   // Add more website-specific configurations as needed
   // Example:
   // {


### PR DESCRIPTION
## Summary
- create NinjaAdapter with basic selectors
- register NinjaAdapter and add exports
- support new site type in sidebar
- include NinjaAI host permissions and content script
- update render config and README

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_6883b6ceb12c83318f7c7720628baa3b